### PR TITLE
[kingdom-integration] API client and cypress tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,223 @@
+# Seraaj v2 Environment Configuration Template
+# Copy this file to .env and fill in your actual values
+
+# =============================================================================
+# ENVIRONMENT SETTINGS
+# =============================================================================
+ENVIRONMENT=development
+DEBUG=true
+HOST=0.0.0.0
+PORT=8000
+
+# =============================================================================
+# DATABASE CONFIGURATION
+# =============================================================================
+# For development (SQLite)
+DATABASE_URL=sqlite:///./seraaj_dev.db
+DATABASE_ECHO=true
+
+# For production (PostgreSQL) - uncomment and configure
+# DATABASE_URL=postgresql://username:password@localhost:5432/seraaj_production
+# DATABASE_ECHO=false
+# DATABASE_POOL_SIZE=5
+# DATABASE_MAX_OVERFLOW=10
+
+# =============================================================================
+# SECURITY CONFIGURATION
+# =============================================================================
+# CRITICAL: Generate a secure secret key for production!
+# Use: python -c "import secrets; print(secrets.token_urlsafe(32))"
+SECRET_KEY=your-secret-key-here-change-in-production-must-be-32-chars-minimum
+
+# JWT Settings
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+REFRESH_TOKEN_EXPIRE_DAYS=7
+
+# Password Security
+PASSWORD_MIN_LENGTH=8
+MAX_LOGIN_ATTEMPTS=5
+LOCKOUT_DURATION_MINUTES=15
+
+# CORS Settings (comma-separated)
+# Include frontend dev URL so browser requests succeed
+CORS_ORIGINS=http://localhost:3031,http://localhost:3030,http://localhost:3000
+CORS_ALLOW_CREDENTIALS=true
+
+# Rate Limiting
+RATE_LIMIT_ENABLED=false
+DEFAULT_RATE_LIMIT=100
+BURST_RATE_LIMIT=200
+
+# =============================================================================
+# REDIS CONFIGURATION (Optional - for caching and sessions)
+# =============================================================================
+REDIS_URL=redis://localhost:6379/0
+REDIS_MAX_CONNECTIONS=10
+REDIS_RETRY_ON_TIMEOUT=true
+REDIS_SOCKET_TIMEOUT=5
+
+# =============================================================================
+# EMAIL CONFIGURATION
+# =============================================================================
+# SMTP Settings
+EMAIL_SMTP_HOST=localhost
+EMAIL_SMTP_PORT=587
+EMAIL_SMTP_USERNAME=
+EMAIL_SMTP_PASSWORD=
+EMAIL_SMTP_TLS=true
+EMAIL_SMTP_SSL=false
+
+# From Address
+EMAIL_FROM_EMAIL=noreply@seraaj.org
+EMAIL_FROM_NAME=Seraaj
+
+# Third-party Email Services (optional)
+EMAIL_SENDGRID_API_KEY=
+EMAIL_MAILGUN_API_KEY=
+EMAIL_MAILGUN_DOMAIN=
+
+# =============================================================================
+# FILE STORAGE CONFIGURATION
+# =============================================================================
+FILE_STORAGE_UPLOAD_DIR=uploads
+FILE_STORAGE_MAX_FILE_SIZE_MB=10
+
+# Cloud Storage (AWS S3) - Optional
+FILE_STORAGE_CLOUD_STORAGE_ENABLED=false
+FILE_STORAGE_AWS_ACCESS_KEY_ID=
+FILE_STORAGE_AWS_SECRET_ACCESS_KEY=
+FILE_STORAGE_AWS_BUCKET_NAME=
+FILE_STORAGE_AWS_REGION=us-east-1
+
+# CDN Settings
+FILE_STORAGE_CDN_ENABLED=false
+FILE_STORAGE_CDN_BASE_URL=
+
+# =============================================================================
+# MACHINE LEARNING CONFIGURATION
+# =============================================================================
+ML_MATCHING_ALGORITHM=collaborative_filtering
+ML_MODEL_UPDATE_FREQUENCY_HOURS=24
+ML_MIN_TRAINING_DATA=100
+ML_SIMILARITY_THRESHOLD=0.7
+
+# AI Service Keys (optional)
+ML_OPENAI_API_KEY=
+ML_HUGGINGFACE_API_KEY=
+
+# =============================================================================
+# PAYMENT PROCESSING CONFIGURATION
+# =============================================================================
+# Stripe Configuration
+PAYMENT_STRIPE_ENABLED=false
+PAYMENT_STRIPE_PUBLIC_KEY=
+PAYMENT_STRIPE_SECRET_KEY=
+PAYMENT_STRIPE_WEBHOOK_SECRET=
+
+# PayPal Configuration
+PAYMENT_PAYPAL_ENABLED=false
+PAYMENT_PAYPAL_CLIENT_ID=
+PAYMENT_PAYPAL_CLIENT_SECRET=
+PAYMENT_PAYPAL_SANDBOX=true
+
+# Fee Configuration
+PAYMENT_PROCESSING_FEE_PERCENTAGE=2.9
+PAYMENT_PROCESSING_FEE_FIXED=0.30
+PAYMENT_PLATFORM_FEE_PERCENTAGE=2.0
+
+# Limits
+PAYMENT_MINIMUM_DONATION=1.00
+PAYMENT_MAXIMUM_DONATION=10000.00
+PAYMENT_DEFAULT_CURRENCY=USD
+
+# =============================================================================
+# PUSH NOTIFICATIONS CONFIGURATION
+# =============================================================================
+# VAPID Keys for Web Push (generate with: npx web-push generate-vapid-keys)
+VAPID_PRIVATE_KEY=demo-vapid-private-key-placeholder
+VAPID_PUBLIC_KEY=BEl62iUYgUivxIkv69yViEuiBIa40HI80NqIUHxHtjZHhr-RNZIwGKvlJ_SiuRzr3MZgJTBhOGXFu6_MmQhOhGE
+
+NOTIFICATION_RETRY_MAX=3
+NOTIFICATION_CLEANUP_DAYS=30
+
+# =============================================================================
+# MONITORING & LOGGING CONFIGURATION
+# =============================================================================
+# Logging
+MONITORING_LOG_LEVEL=INFO
+MONITORING_LOG_FORMAT=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+MONITORING_LOG_FILE=logs/seraaj.log
+MONITORING_LOG_RETENTION_DAYS=30
+
+# Performance Monitoring
+MONITORING_SLOW_QUERY_THRESHOLD_MS=1000
+MONITORING_SLOW_REQUEST_THRESHOLD_MS=2000
+
+# External Monitoring Services (optional)
+MONITORING_SENTRY_DSN=
+MONITORING_PROMETHEUS_ENABLED=false
+MONITORING_PROMETHEUS_PORT=8000
+
+# =============================================================================
+# WEBSOCKET CONFIGURATION
+# =============================================================================
+WEBSOCKET_MAX_CONNECTIONS=1000
+WEBSOCKET_HEARTBEAT_INTERVAL=30
+WEBSOCKET_CONNECTION_TIMEOUT=60
+WEBSOCKET_MESSAGE_QUEUE_SIZE=100
+
+# Redis for WebSocket Scaling (optional)
+WEBSOCKET_REDIS_ENABLED=false
+WEBSOCKET_REDIS_CHANNEL_PREFIX=seraaj:ws:
+
+# =============================================================================
+# API CONFIGURATION
+# =============================================================================
+API_TITLE=Seraaj API
+API_DESCRIPTION=Two-sided volunteer marketplace for MENA nonprofits
+API_VERSION=2.0.0
+
+# API Documentation URLs
+API_DOCS_URL=/docs
+API_REDOC_URL=/redoc
+API_OPENAPI_URL=/openapi.json
+
+# Request/Response Settings
+API_MAX_REQUEST_SIZE_MB=50
+API_REQUEST_TIMEOUT_SECONDS=30
+
+# Pagination Defaults
+API_DEFAULT_PAGE_SIZE=20
+API_MAX_PAGE_SIZE=100
+
+# =============================================================================
+# FRONTEND CONFIGURATION (for Next.js)
+# =============================================================================
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_WEBSOCKET_URL=ws://localhost:8000
+NEXT_PUBLIC_APP_NAME=Seraaj
+NEXT_PUBLIC_APP_VERSION=2.0.0
+
+# =============================================================================
+# DEVELOPMENT TOOLS
+# =============================================================================
+# Set to true to enable development features
+DEV_ENABLE_SWAGGER_UI=true
+DEV_ENABLE_REDOC=true
+DEV_ENABLE_DEBUG_LOGGING=true
+DEV_ENABLE_HOT_RELOAD=true
+
+# Test Database (for running tests)
+TEST_DATABASE_URL=sqlite:///:memory:
+
+# =============================================================================
+# PRODUCTION OVERRIDES
+# =============================================================================
+# When ENVIRONMENT=production, these settings will be enforced:
+# - DEBUG=false
+# - DATABASE_ECHO=false
+# - SECRET_KEY must be changed from default
+# - CORS_ORIGINS should be production domains only
+# - RATE_LIMIT_ENABLED=true
+# - All monitoring should be enabled

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!apps/web/lib/
 lib64/
 parts/
 sdist/

--- a/apps/api/config/settings.py
+++ b/apps/api/config/settings.py
@@ -71,7 +71,8 @@ class SecurityConfig(BaseSettings):
     lockout_duration_minutes: int = 15
 
     # CORS settings
-    cors_origins: str = ""  # Comma-separated string from environment
+    # Allow overriding via CORS_ORIGINS for simplicity
+    cors_origins: str = os.getenv("CORS_ORIGINS", "")
     cors_allow_credentials: bool = True
     cors_allow_methods: List[str] = ["*"]
     cors_allow_headers: List[str] = ["*"]

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,0 +1,122 @@
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export interface RegisterData {
+  email: string;
+  password: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+export interface User {
+  id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  role: string;
+}
+
+export interface Opportunity {
+  id: string;
+  title: string;
+  description: string;
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+let token: string | null = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+
+function buildHeaders(hasBody = false): HeadersInit {
+  const headers: HeadersInit = {};
+  if (hasBody) {
+    headers['Content-Type'] = 'application/json';
+  }
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+async function handleResponse<T>(res: Response): Promise<ApiResponse<T>> {
+  let payload: any = null;
+  try {
+    payload = await res.json();
+  } catch {}
+  if (!res.ok) {
+    const message = payload?.detail || payload?.message || res.statusText;
+    return { success: false, error: message };
+  }
+  return { success: true, data: payload };
+}
+
+export const auth = {
+  isAuthenticated(): boolean {
+    return !!token;
+  },
+  async login(credentials: LoginCredentials): Promise<ApiResponse<{access_token: string}>> {
+    const res = await fetch(`${API_BASE_URL}/v1/auth/login`, {
+      method: 'POST',
+      headers: buildHeaders(true),
+      body: JSON.stringify(credentials),
+    });
+    const result = await handleResponse<{access_token: string}>(res);
+    if (result.success && result.data?.access_token) {
+      token = result.data.access_token;
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('token', token);
+      }
+    }
+    return result;
+  },
+  async register(data: RegisterData): Promise<ApiResponse<any>> {
+    const res = await fetch(`${API_BASE_URL}/v1/auth/register`, {
+      method: 'POST',
+      headers: buildHeaders(true),
+      body: JSON.stringify(data),
+    });
+    return handleResponse(res);
+  },
+  async logout(): Promise<ApiResponse<any>> {
+    const res = await fetch(`${API_BASE_URL}/v1/auth/logout`, {
+      method: 'POST',
+      headers: buildHeaders(),
+    });
+    const result = await handleResponse(res);
+    token = null;
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('token');
+    }
+    return result;
+  },
+  async getCurrentUser(): Promise<ApiResponse<User>> {
+    const res = await fetch(`${API_BASE_URL}/v1/auth/me`, {
+      headers: buildHeaders(),
+    });
+    return handleResponse<User>(res);
+  },
+};
+
+export const opportunities = {
+  async getAll(params: Record<string, any> = {}): Promise<ApiResponse<Opportunity[]>> {
+    const query = new URLSearchParams(params as any).toString();
+    const res = await fetch(`${API_BASE_URL}/v1/opportunities/${query ? `?${query}` : ''}`, {
+      headers: buildHeaders(),
+    });
+    return handleResponse<Opportunity[]>(res);
+  },
+  async apply(id: string): Promise<ApiResponse<any>> {
+    const res = await fetch(`${API_BASE_URL}/v1/opportunities/${id}/apply`, {
+      method: 'POST',
+      headers: buildHeaders(),
+    });
+    return handleResponse(res);
+  },
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "cypress run"
   },
   "dependencies": {
     "clsx": "^2.0.0",
@@ -24,6 +25,7 @@
     "eslint-config-next": "14.2.30",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "cypress": "^13"
   }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "cypress"]
 }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3030',
+    supportFile: 'cypress/support/e2e.ts',
+    specPattern: 'cypress/integration/**/*.cy.ts',
+  },
+});

--- a/cypress/integration/application.cy.ts
+++ b/cypress/integration/application.cy.ts
@@ -1,0 +1,11 @@
+describe('Opportunity Application', () => {
+  before(() => {
+    cy.login('layla@example.com', 'Demo123!');
+  });
+
+  it('submits an application from the feed', () => {
+    cy.visit('/feed');
+    cy.get('button').contains('Apply').first().click();
+    cy.contains('Application submitted');
+  });
+});

--- a/cypress/integration/feed.cy.ts
+++ b/cypress/integration/feed.cy.ts
@@ -1,0 +1,10 @@
+describe('Activity Feed', () => {
+  before(() => {
+    cy.login('layla@example.com', 'Demo123!');
+  });
+
+  it('loads opportunities', () => {
+    cy.visit('/feed');
+    cy.contains('Opportunities');
+  });
+});

--- a/cypress/integration/login.cy.ts
+++ b/cypress/integration/login.cy.ts
@@ -1,0 +1,9 @@
+describe('Login Flow', () => {
+  it('allows a user to log in', () => {
+    cy.visit('/auth/login');
+    cy.get('input[name="email"]').type('layla@example.com');
+    cy.get('input[name="password"]').type('Demo123!');
+    cy.contains('button', 'Login').click();
+    cy.url().should('include', '/feed');
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,0 +1,9 @@
+Cypress.Commands.add('login', (email: string, password: string) => {
+  cy.visit('/auth/login');
+  cy.get('input[name="email"]').type(email);
+  cy.get('input[name="password"]').type(password);
+  cy.contains('button', 'Login').click();
+  cy.url().should('include', '/feed');
+});
+
+export {};

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,1 @@
+import './commands';

--- a/tests/api_frontend_bridge.py
+++ b/tests/api_frontend_bridge.py
@@ -1,0 +1,9 @@
+import requests
+
+BASE_URL = 'http://localhost:8000'
+
+# Simple check that API health endpoint is reachable under /v1 prefix
+
+def test_health_endpoint():
+    resp = requests.get(f"{BASE_URL}/v1/system/health", timeout=5)
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add CORS_ORIGINS env var example
- allow overriding CORS origins in backend settings
- implement frontend API client
- add cypress tests for login, feed, and application
- add cypress config and test commands

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm run typecheck` *(fails: turbo not found)*
- `pnpm test` *(fails: turbo not found)*
- `pytest tests/api_frontend_bridge.py` *(fails: plugin error)*

------
https://chatgpt.com/codex/tasks/task_e_688cecc4e1d0832095d4db5d599638ff